### PR TITLE
Fix: Non-intersecting lines with one endpoint colinear to the other line

### DIFF
--- a/src/plane.jl
+++ b/src/plane.jl
@@ -125,7 +125,7 @@ function meet(p, q, a, b)
 
     if opposite_signs(pqa, pqb) && opposite_signs(abp, abq)
         return 1
-    elseif pqa * pqb == 1 || abp * abq == 1
+    elseif (pqa != 0 && pqa == pqb)  || (abq != 0  && abp == abq)
         return -1
     elseif pqa == 0 && pqb == 0
         # all four points are collinear

--- a/src/plane.jl
+++ b/src/plane.jl
@@ -125,7 +125,7 @@ function meet(p, q, a, b)
 
     if opposite_signs(pqa, pqb) && opposite_signs(abp, abq)
         return 1
-    elseif pqa & pqb == 1 || abp & abq == 1
+    elseif pqa * pqb == 1 || abp * abq == 1
         return -1
     elseif pqa == 0 && pqb == 0
         # all four points are collinear

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -175,6 +175,15 @@ end
     @test meet(p2(0), p2(1), p2(3), p2(4)) == -1
     @test meet(p2(0), p2(3), p2(1), p2(4)) == 0
     @test meet(p2(1), p2(4), p2(1), p2(2)) == 0
+
+    a = (0.0, 0.0)
+    b = (2.0, 2.0)
+    c = (-3., -8.)
+    d = (-1., -1.)
+    @test meet(a, b, c, d) == -1
+    @test meet(c, d, a, b) == -1
+
+
 end
 
 


### PR DESCRIPTION
  - When two lines are not intersecting but one endpoint is collinear to
    the other line the meet function should return -1

  - Condition for Non-intersecting lines have been modified from
            pqa & pqb == 1 || abp & abq == 1
    to
            pqa * pqb == 1 || abp * abq == 1

  - One test have been added

Of course, I can also be wrong.