### PR TITLE
Use Aqua.jl in tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,9 +9,8 @@ version = "2.2.5"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-IntervalArithmetic = "^0.20"
+IntervalArithmetic = "0.20"
 StaticArraysCore = "^1.4"
 julia = "^1.1"

--- a/src/Codegen.jl
+++ b/src/Codegen.jl
@@ -89,6 +89,7 @@ end
 zero(::Type{Formula}) = convert(Formula, 0)
 
 promote_rule(::Type{T}, ::Type{Formula}) where {T <: Integer} = Formula
+promote_rule(::Type{Bool}, ::Type{Formula}) = Formula # method ambiguity
 
 
 function group!(args...)
@@ -361,7 +362,7 @@ end
 
 """
 
-Generate sign predicate for a function that compute a polynomial in the
+Generate sign predicate for a function that computes a polynomial in the
 coordinates of the arguments.
 
 """

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+Aqua = "0.7"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -222,3 +222,9 @@ end
     @test lengthcompare(a, b, c, d) == -1
     @test lengthcompare(c, (c[1]+d[1], c[2]+d[2]), a, b) == -1
 end
+
+@testset "Aqua" begin
+    using Aqua
+    Aqua.test_all(ExactPredicates; ambiguities=false, project_extras=false)
+    Aqua.test_ambiguities(ExactPredicates) # don't pick up Base and Core
+end


### PR DESCRIPTION
This introduces Aqua.jl into the tests. Not really important, but just noticed that this package depends directly on Test.jl which would've been noticed by Aqua.jl, so for future safety it's nice to keep Aqua.jl in here. This also picked up on a method ambiguity with `promote_rule` (that I don't think will ever actually get called, so doesn't really matter) that I've fixed.

This change also now puts a Project into the test folder, separating the main project. This is so that Aqua.jl can safely have its own compat and you don't need to depend on it. This might be a bit annoying when you try and run the test file directly, since each call to `ExactPredicates` in `using` or `import` needs to be replaced with a `.ExactPredicates` (or do `]dev ExactPredicates` with the test project activated, I guess, just remember to remove it later). Hope that's fine.

(The `promote_rule` function is actually a bit problematic I think, it invalidates some `promote_rule` functions with integers in base, specifically:
```julia
 inserting promote_rule(::Type{T}, ::Type{ExactPredicates.Codegen.Formula}) where T<:Integer @ ExactPredicates.Codegen C:\Users\User\.julia\dev\ExactPredicates\src\Codegen.jl:91 invalidated:
   backedges: 1: superseding promote_rule(::Type, ::Type) @ Base promotion.jl:325 with MethodInstance for promote_rule(::Type{UInt8}, ::Type) (3 children)
              2: superseding promote_rule(::Type, ::Type) @ Base promotion.jl:325 with MethodInstance for promote_rule(::Type{Int128}, ::Type) (3 children)
              3: superseding promote_rule(::Type, ::Type) @ Base promotion.jl:325 with MethodInstance for promote_rule(::Type{Int64}, ::Type) (6 children)
```
although I'm not really sure this matters unless you want to depend on PrecompileTools.jl directly.)