### PR TITLE
Bump compatibility with IntervalArithmetic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 
 [compat]
-IntervalArithmetic = "^0.21"
+IntervalArithmetic = "^0.21, 0.22"
 StaticArraysCore = "^1.4"
 julia = "^1.1"


### PR DESCRIPTION
Currently one can not use the latest version of IntervalArithmetic v0.22 and the latest version of Makie due to a compatibility issue. This PR resolves this issue by adding "0.22" in the compat entry.

I do not know how this package relies on IntervalArithmetic, but fyi, 0.21 and 0.22 have quite a few breaking changes. I can help providing pointers to update the code if need be. 🙂