### PR TITLE
Bump IntervalArithmetic compat version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-IntervalArithmetic = "^0.21, 0.22"
+IntervalArithmetic = "^0.21, 0.22, 0.23, 1"
 StaticArrays = "^1.9"
 julia = "^1.1"


### PR DESCRIPTION
This package is not concerned by the few changes made in 0.23, and new release 1.0 of IntervalArithmetic 🙂 

Hopefully this PR can be merged fast, as it creates a "compatibility constraints" (preventing using IntervalArithmetic 1.0) via the Makie ecosystem.